### PR TITLE
Special 413 handling

### DIFF
--- a/files/error/error-413.php
+++ b/files/error/error-413.php
@@ -1,0 +1,10 @@
+<?php
+
+// This is an error page returning status code 413 with CORS headers present.
+// Use this via includes/handle-413.conf.
+
+http_response_code(413);
+
+header("Access-Control-Allow-Headers: origin, content-type, authorization, content-length");
+header("Access-Control-Allow-Methods: OPTIONS, GET, POST");
+header("Access-Control-Allow-Origin: *");

--- a/files/includes/drupal-server.conf
+++ b/files/includes/drupal-server.conf
@@ -1,3 +1,5 @@
+include includes/handle-413.conf;
+
 location / {
     # Don't touch PHP for static content.
     try_files $uri /index.php?$query_string;

--- a/files/includes/drupal-server.conf
+++ b/files/includes/drupal-server.conf
@@ -1,5 +1,3 @@
-include includes/handle-413.conf;
-
 location / {
     # Don't touch PHP for static content.
     try_files $uri /index.php?$query_string;

--- a/files/includes/handle-413.conf
+++ b/files/includes/handle-413.conf
@@ -1,0 +1,12 @@
+# Handle 413 errors so that they are sent to the client with CORS headers.
+# Nginx does not allow add_header on erroneous responses, so the work is offloaded to a PHP script.
+
+error_page 413 = @413;
+
+location @413 {
+  # Avoid looping
+  fastcgi_intercept_errors off;
+  fastcgi_param SCRIPT_FILENAME "/etc/nginx/error/error-413.php";
+  include fastcgi_params;
+  fastcgi_pass 127.0.0.1:9000;
+}

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -20,6 +20,20 @@
     src: templates/50x.html.j2
     dest: /etc/nginx/50x.html
 
+- name: Ensure that error dir exists
+  file:
+    path: "/etc/nginx/error/"
+    state: directory
+    owner: "{{ nginx_user }}"
+    group: "{{ nginx_group }}"
+
+- name: Copy PHP error 413 file
+  copy:
+    src: error/error-413.php
+    dest: /etc/nginx/error/error-413.php
+    owner: "{{ nginx_user }}"
+    group: "{{ nginx_group }}"
+
 - name: Create extra includes from config
   copy:
     content: "{{ item.value }}"


### PR DESCRIPTION
This adds two files that are not used by default to handle 413 errors while allowing CORS requests.

This is required so GraphQL applications can know what went wrong when uploading a file.

I'm committing this to this repo instead of aava-cm-infra because I believe it can be reused on sites using GraphQL. I did not make it active by default since it makes error pages ugly for regular use.